### PR TITLE
Use constant-time secure comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ addEventListener("fetch", (e) => {
     e.respondWith(unauthorized);
     return;
   }
-  e.respondWith(new Response("Your are authorized!"));
+  e.respondWith(new Response("You are authorized!"));
 });
 ```
 

--- a/mod.ts
+++ b/mod.ts
@@ -16,7 +16,7 @@ import secureCompare from "https://deno.land/x/secure_compare@1.0.0/mod.ts";
  *     e.respondWith(unauthorized);
  *     return;
  *   }
- *   e.respondWith(new Response("Your are authorized!"));
+ *   e.respondWith(new Response("You are authorized!"));
  * });
  * ```
  */

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,5 @@
+import secureCompare from "https://deno.land/x/secure_compare@1.0.0/mod.ts";
+
 /**
  * Authenticates the given request with the given user-password table.
  * Returns unauthorized response if the request is not authenticated, otherwise
@@ -28,8 +30,9 @@ export function basicAuth(
     const match = authorization.match(/^Basic\s+(.*)$/);
     if (match) {
       const [user, pw] = atob(match[1]).split(":");
-      for (const [u, p] of Object.entries(userPasswordTable)) {
-        if (user === u && pw == p) {
+      if (Object.prototype.hasOwnProperty.call(userPasswordTable, user)) {
+        const expectedPw = userPasswordTable[user];
+        if (secureCompare(pw, expectedPw)) {
           return;
         }
       }


### PR DESCRIPTION
This makes the code use the https://deno.land/x/secure_compare module for comparing the supplied password to the expected password in order to prevent timing attacks. Using `==` to compare the supplied password to the expected password can take a variable amount of time depending on how much of the passwords match and could be exploited to reveal the server's expected password.

Also this fixes a typo.