### PR TITLE
Add "null" to MapWithGettableValues

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,7 +1,7 @@
 import secureCompare from "https://deno.land/x/secure_compare@1.0.0/mod.ts";
 
 export interface MapWithGettableValues {
-  get(headerName: string): string;
+  get(headerName: string): string | null;
 }
 
 export interface Requestlike {


### PR DESCRIPTION
According to MDN's Headers specification, the get method is null in some cases.

https://developer.mozilla.org/en-US/docs/Web/API/Headers/get#return_value